### PR TITLE
More practical load of data files

### DIFF
--- a/2021.html
+++ b/2021.html
@@ -1,0 +1,13 @@
+---
+layout: default
+---
+
+<div id="main">
+	<div class="container">
+		<h1>Promotion 2021</h1>
+		<p>Portail vers des projets en lien avec la promo 2021</p>
+
+		{% assign data = site.data.2021 %}
+		{% include data-loader.html %}
+	</div>
+</div>

--- a/2022.html
+++ b/2022.html
@@ -1,0 +1,13 @@
+---
+layout: default
+---
+
+<div id="main">
+	<div class="container">
+		<h1>Promotion 2022</h1>
+		<p>Portail vers des projets en lien avec la promo 2022</p>
+
+		{% assign data = site.data.2022 %}
+		{% include data-loader.html %}
+	</div>
+</div>

--- a/2023.html
+++ b/2023.html
@@ -1,0 +1,13 @@
+---
+layout: default
+---
+
+<div id="main">
+	<div class="container">
+		<h1>Promotion 2023</h1>
+		<p>Portail vers des projets en lien avec la promo 2023</p>
+
+		{% assign data = site.data.2023 %}
+		{% include data-loader.html %}
+	</div>
+</div>

--- a/2024.html
+++ b/2024.html
@@ -1,0 +1,13 @@
+---
+layout: default
+---
+
+<div id="main">
+	<div class="container">
+		<h1>Promotion 2024</h1>
+		<p>Portail vers des projets en lien avec la promo 2024</p>
+
+		{% assign data = site.data.2024 %}
+		{% include data-loader.html %}
+	</div>
+</div>

--- a/404.html
+++ b/404.html
@@ -17,19 +17,13 @@ permalink: /404.html
 
 <script>
 // Redirections!
+// Disabled for now
+/*
 (function() {
 	var pathname = document.location.pathname.toLowerCase();
-	if (pathname.startsWith('/2021')) {
-		window.location.href = 'https://discordapp.com/invite/WbhavjX';
-	}
-	else if (pathname.startsWith('/2022')) {
-		window.location.href = 'https://discordapp.com/invite/geJBr2J';
-	}
-	else if (pathname.startsWith('/2023')) {
-		window.location.href = 'https://discordapp.com/invite/8eVWhxm';
-	}
-	else if (pathname.startsWith('/2024')) {
-		window.location.href = 'https://discordapp.com/invite/TUHpqPn';
+	if (pathname.startsWith('/path')) {
+		// window.location.href = '#';
 	}
 })();
+*/
 </script>

--- a/_data/2021.yml
+++ b/_data/2021.yml
@@ -1,0 +1,8 @@
+- title: Communauté étudiante
+  items:
+  - name: Discord EPITA 2021
+    href: https://discordapp.com/invite/WbhavjX
+    class: tile-wide
+    style:
+    - 'background-color: #202225'
+    - 'background-image: url(https://cdn.discordapp.com/icons/364120280072716309/da24989523fa2b5ffa995efebb6bf5b2.png?size=256)'

--- a/_data/2022.yml
+++ b/_data/2022.yml
@@ -1,0 +1,8 @@
+- title: Communauté étudiante
+  items:
+  - name: Discord EPITA 2022
+    href: https://discordapp.com/invite/geJBr2J
+    class: tile-wide
+    style:
+    - 'background-color: #202225'
+    - 'background-image: url(https://cdn.discordapp.com/icons/352524741980061698/1354631b275be398828293db89515300.png?size=256)'

--- a/_data/2023.yml
+++ b/_data/2023.yml
@@ -1,0 +1,8 @@
+- title: Communauté étudiante
+  items:
+  - name: Discord EPITA 2023
+    href: https://discordapp.com/invite/8eVWhxm
+    class: tile-wide
+    style:
+    - 'background-color: #202225'
+    - 'background-image: url(https://cdn.discordapp.com/icons/415982150714916874/756eb354fd78ceb10c60c59a03eb8111.png?size=256)'

--- a/_data/2024.yml
+++ b/_data/2024.yml
@@ -1,0 +1,8 @@
+- title: Communauté étudiante
+  items:
+  - name: Discord EPITA 2024
+    href: https://discordapp.com/invite/TUHpqPn
+    class: tile-wide
+    style:
+    - 'background-color: #202225'
+    - 'background-image: url(https://cdn.discordapp.com/icons/517081450491805710/249311d3f9be4565bafc1dcf4c037aaa.png?size=256)'

--- a/_includes/data-loader.html
+++ b/_includes/data-loader.html
@@ -1,0 +1,8 @@
+{% for section in data %}
+	<h2>{{ section.title }}</h2>
+	
+	{% assign grid = section.items %}
+	{% include grid-loader.html %}
+	
+	{% unless forloop.last %}<hr />{% endunless %}
+{% endfor %}

--- a/_includes/grid-loader.html
+++ b/_includes/grid-loader.html
@@ -1,0 +1,17 @@
+<div class="tiles-grid">
+	{% for item in grid %}
+		{% if item.items %}
+			<div class="{{ item.class }}">
+				{% for subitem in item.items %}
+					<a href="{{ subitem.href }}" class="{{ subitem.class }}" style="{% for rule in subitem.style %}{{ rule }}{% unless forloop.last %}; {% endunless %}{% endfor %}">
+						<span class="branding-bar">{{ subitem.name }}</span>
+					</a>
+				{% endfor %}
+			</div>
+		{% else %}
+			<a href="{{ item.href }}" class="{{ item.class }}" style="{% for rule in item.style %}{{ rule }}{% unless forloop.last %}; {% endunless %}{% endfor %}">
+				<span class="branding-bar">{{ item.name }}</span>
+			</a>
+		{% endif %}
+	{% endfor %}
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,10 +28,11 @@
 	
 	<div id="footer">
 		<div class="container">
-			Made with <i class="fas fa-heart fa-fw text-danger"></i> by an EPITA student.
+			<p>Made with <i class="fas fa-heart fa-fw text-danger"></i> by an EPITA student.</p>
 			<ul>
-				<!--<li><a href="{{ 'tos.html' | relative_url }}">Conditions générales</a></li>-->
-				<li><a href="{{ site.github.repository_url }}">Contribuez sur Github</a></li>
+				<li><a href="{{ site.github.repository_url }}" class="btn btn-primary btn-sm">Contribuez sur Github</a></li>
+				<li><a href="https://epidocs.eu/" class="btn btn-info btn-sm">Géré par Epidocs</a></li>
+				<!-- <li><a href="{{ 'tos.html' | relative_url }}" class="btn btn-primary btn-sm">Conditions générales</a></li> -->
 			</ul>
 		</div>
 	</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,16 @@
 <body>
 
 	{{ content }}
+	
+	<div id="footer">
+		<div class="container">
+			Made with <i class="fas fa-heart fa-fw text-danger"></i> by an EPITA student.
+			<ul>
+				<!--<li><a href="{{ 'tos.html' | relative_url }}">Conditions générales</a></li>-->
+				<li><a href="{{ site.github.repository_url }}">Contribuez sur Github</a></li>
+			</ul>
+		</div>
+	</div>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -34,13 +34,3 @@ layout: default
 		</div>
 	</div>
 </div>
-
-<div id="footer">
-	<div class="container">
-		Made with <i class="fas fa-heart fa-fw text-danger"></i> by an EPITA student.
-		<ul>
-			<!--<li><a href="{{ 'tos.html' | relative_url }}">Conditions générales</a></li>-->
-			<li><a href="{{ site.github.repository_url }}">Contribuez sur Github</a></li>
-		</ul>
-	</div>
-</div>

--- a/index.html
+++ b/index.html
@@ -7,30 +7,17 @@ layout: default
 		<h1>EPITA.it</h1>
 		<p>Portail vers des services en lien avec l'EPITA</p>
 
+		{% assign grid = site.data.links %}
+		{% include grid-loader.html %}
+		
+		<!--
 		<div class="tiles-grid">
-			<!--
 			<div class="tile-medium">
 				<span class="icon fab fa-facebook fa-fw"></span>
 				<span class="branding-bar">Facebook</span>
 				<span class="badge-bottom">10</span>
 			</div>
-			-->
-			
-			{% for item in site.data.links %}
-				{% if item.items %}
-					<div class="{{ item.class }}">
-						{% for subitem in item.items %}
-							<a href="{{ subitem.href }}" class="{{ subitem.class }}" style="{% for rule in subitem.style %}{{ rule }}{% unless forloop.last %}; {% endunless %}{% endfor %}">
-								<span class="branding-bar">{{ subitem.name }}</span>
-							</a>
-						{% endfor %}
-					</div>
-				{% else %}
-					<a href="{{ item.href }}" class="{{ item.class }}" style="{% for rule in item.style %}{{ rule }}{% unless forloop.last %}; {% endunless %}{% endfor %}">
-						<span class="branding-bar">{{ item.name }}</span>
-					</a>
-				{% endif %}
-			{% endfor %}
 		</div>
+		-->
 	</div>
 </div>


### PR DESCRIPTION
Added files for data files loading:
- `_includes/grid-loader.html`, for loading a single grid from a list of links.
- `_includes/data-loader.html`, for loading a page with multiples sections of links.

Additionally, pages for different promotions have been created:
- `2021.html`
- `2022.html`
- `2023.html`
- `2024.html`

These page contain a link to their Discord server, through their data file.
Therefore, redirections to these Discord servers have been removed from `404.html`