### PR TITLE
Make the footer stay at the bottom

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,3 +1,7 @@
+html {
+	height: 100%;
+}
+
 body {
 	font-family: 'Roboto', sans-serif;
 	background: #204060;
@@ -5,6 +9,9 @@ body {
 	padding: 0;
 	overflow-x: hidden;
 	color: #fff;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
 }
 
 #navbar {
@@ -13,9 +20,12 @@ body {
 
 #main {
 	max-width: 960px;
+	min-width: 66%;
 	margin: 0 auto;
 	padding: 20px 0;
+	flex: 1 0 auto;
 }
+
 #main h1 {
 	font-size: 4em;
 	font-weight: bold;
@@ -24,6 +34,7 @@ body {
 #footer {
 	background: rgba(0, 0, 0, .1);
 	padding: 20px;
+	flex-shrink: 0;
 }
 @media (min-width: 992px) {
 	#footer .container {


### PR DESCRIPTION
This commit makes the footer of the website stay at the bottom of the page through a simple flexbox setup + adding some css to make the page take the entire space available.

Before:
![image](https://user-images.githubusercontent.com/5175705/62009052-e47bc380-b15a-11e9-89d9-8cba6a58d844.png)

After:
![image](https://user-images.githubusercontent.com/5175705/62009054-ed6c9500-b15a-11e9-987e-c8f47cc5f73b.png)
