### PR TITLE
Replace zoroark.guru with kb.zoroark.guru

### DIFF
--- a/_data/links.yml
+++ b/_data/links.yml
@@ -161,12 +161,11 @@
   - 'background-color: #1254a4'
   - 'background-image: url(https://redux.epita.cf/img/logo.png)'
   
-- name: Zoroark.guru
-  href: https://zoroark.guru/
+- name: Knowledge Base
+  href: https://kb.zoroark.guru/
   class: tile-medium
   style:
-  - 'background-color: #424242'
-  - 'background-image: url(https://zoroark.guru/favicon.png)'
+  - 'background: url(https://zoroark.guru/img/kb.png) center/cover'
   
 - name: Epidocs
   href: https://epidocs.eu/


### PR DESCRIPTION
kb.zoroark.guru is much more relevant and useful as the first one has pretty much become my personal ~~salt~~ repository ¯\\\_(ツ)_/¯