### PR TITLE
Update ACDC/ACU/KB icons + add jekyll cache in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _site/
+.jekyll-cache/

--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -15,7 +15,8 @@
     style:
     - 'background-color: #424242'
     - 'background-image: url(https://kb.zoroark.guru/favicon.png)'
-    - 'background-size: 90%'
+    - 'background-position-y: 10%'
+    - 'background-size: 70%'
     
 - title: Guides
   items:

--- a/_data/links.yml
+++ b/_data/links.yml
@@ -38,8 +38,9 @@
   href: https://acdc.epita.fr/
   class: tile-wide
   style:
-  - 'background-color: #922b2c'
-  - 'background-image: url(https://acdc.epita.fr/media/themes/img/header2021.gif)'
+  - 'background-color: #577899'
+  - 'background-image: url(https://acdc.epita.fr/media/themes/img/header2022_g4QyGpn.png)'
+  - 'background-size: 75%'
   
 - name: IonisX
   href: https://ionisx.com/
@@ -53,10 +54,10 @@
   href: https://assistants.epita.fr/
   class: tile-medium
   style:
-  - 'background-color: #684e8c'
-  - 'background-image: url(https://assistants.epita.fr/logos/yaka2020_logo.svg), url(https://assistants.epita.fr/lightnoise.png)'
-  - 'background-size: 90%, auto'
-  - 'background-repeat: no-repeat, repeat'
+  - 'background-color: #222'
+  - 'background-image: url(https://assistants.epita.fr/logos/acu2020_logo.svg)'
+  - 'background-position-y: 20%'
+  - 'background-size: 50%'
   
 - name: Chronos
   href: http://chronos.epita.net/

--- a/_data/links.yml
+++ b/_data/links.yml
@@ -55,9 +55,10 @@
   class: tile-medium
   style:
   - 'background-color: #222'
-  - 'background-image: url(https://assistants.epita.fr/logos/acu2020_logo.svg)'
+  - 'background-image: url(https://assistants.epita.fr/logos/acu2020_logo.svg), url(https://assistants.epita.fr/lightnoise.png)'
   - 'background-position-y: 20%'
-  - 'background-size: 50%'
+  - 'background-size: 50%, auto'
+  - 'background-repeat: no-repeat, repeat'
   
 - name: Chronos
   href: http://chronos.epita.net/


### PR DESCRIPTION
* Updated the ACDC and ACU icons (ACDC 2021 -> ACDC 2020, YAKA 2020 -> ACU 2020) and updated scaling
* Scaled the kb.zoroark.guru icon (recent icon change thanks to the original artist providing a clean version of the little Zoroark head)
* Added `.jekyll-cache` to the gitignore -- I don't know why but it just suddenly popped up, might be related to the new Jekyll version (4.0.0).