### PR TITLE
Changed URL of S2 Project Starter Guide

### DIFF
--- a/_data/2024.yml
+++ b/_data/2024.yml
@@ -10,7 +10,7 @@
 - title: Misc.
   items:
   - name: Guide de survie Projet S2 (FR)
-    href: https://sheatnoisette.github.io/SupProjectStarterGuide/
+    href: https://s2guide.epita.it/
     class: tile-wide text-dark
     style:
     - 'background-color: #FFFFFF'

--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -21,7 +21,7 @@
 - title: Guides
   items:
   - name: Guide de survie Projet S2 (FR)
-    href: https://sheatnoisette.github.io/SupProjectStarterGuide/
+    href: https://s2guide.epita.it/
     class: tile-wide text-dark
     style:
     - 'background-color: #ffffff'


### PR DESCRIPTION
Changed the URL of the S2 Project Starter Guide from https://sheatnoisette.github.io/SupProjectStarterGuide/ to https://s2guide.epita.it/