### PR TITLE
Add a community badge to community resources

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -3,6 +3,7 @@
   - name: Documentation EPITA (CRI)
     href: https://doc.cri.epita.fr/
     class: tile-wide
+    icon: fas fa-star
     style:
     - 'background-color: #2980b9'
     - 'background-image: url(https://upload.wikimedia.org/wikipedia/commons/b/b3/Book_font_awesome.svg)'

--- a/_data/links.yml
+++ b/_data/links.yml
@@ -95,12 +95,14 @@
 - class: tile-medium
   items:
   - name: iChronos
+    icon: fas fa-user-friends
     href: https://ichronos.net/
     class: tile-small-wide
     style:
     - 'background-color: #616161'
     
   - name: Map EPITA
+    icon: fas fa-user-friends fab
     href: http://map.epita.eu/
     class: tile-small-wide text-dark
     style:
@@ -214,6 +216,7 @@
 - name: Past-Exams
   href: https://past-exams.epidocs.eu/
   class: tile-medium
+  icon: fas fa-user-friends
   style:
   - 'background-color: #24292e'
   - 'background-image: url(https://epidocs.eu/assets/logo.png)'
@@ -222,6 +225,7 @@
 - name: Redux
   href: https://redux.epita.cf/
   class: tile-medium
+  icon: fas fa-user-friends
   style:
   - 'background-color: #1254a4'
   - 'background-image: url(https://redux.epita.cf/img/logo.png)'
@@ -229,18 +233,21 @@
 - name: HyperAnnales
   href: https://annales.hyperion.tf/
   class: tile-small-wide text-dark
+  icon: fas fa-user-friends
   style:
   - 'background-color: #eee'
   
 - name: Mastercorp
   href: http://mastercorp.epita.eu/
   class: tile-small-wide text-dark
+  icon: fas fa-user-friends
   style:
   - 'background-color: #fff'
   
 - name: EpiPortal
   href: https://epiportal.com/
   class: tile-small-wide text-dark
+  icon: fas fa-user-friends
   style:
   - 'background-color: #fafafa'
   
@@ -294,6 +301,7 @@
 - name: Dyjix
   href: https://dyjix.eu/
   class: tile-small-wide text-dark
+  icon: fas fa-user-friends
   style:
   - 'background-color: #fff'
   - 'background-image: url(https://dyjix.eu/images/vesta_logo.png)'

--- a/_data/links.yml
+++ b/_data/links.yml
@@ -305,5 +305,6 @@
   style:
   - 'background-color: #fff'
   - 'background-image: url(https://dyjix.eu/images/vesta_logo.png)'
-  - 'background-size: 90%'
+  - 'background-size: 70%'
+  - 'background-position-x: 25%'
   - 'background-position-y: 25%'

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -60,12 +60,13 @@ p img { height: 1rem }
 	text-align: initial;
 }
 
-.tile-small .branding-icon,
-.tile-small-wide .branding-icon,
-.tile-medium .branding-icon,
-.tile-wide .branding-icon,
-.tile-large .branding-icon,
-.tile-app .branding-icon {
+#main .container > .tiles-grid { margin-bottom: 1rem }
+#main .tiles-grid .tile-small .branding-icon,
+#main .tiles-grid .tile-small-wide .branding-icon,
+#main .tiles-grid .tile-medium .branding-icon,
+#main .tiles-grid .tile-wide .branding-icon,
+#main .tiles-grid .tile-large .branding-icon,
+#main .tiles-grid .tile-app .branding-icon {
 	position: absolute;
 	left: 0;
 	top: 0;
@@ -94,3 +95,5 @@ p img { height: 1rem }
 #footer ul > li { display: inline-block }
 #footer ul > li + li { margin-left: 5px }
 #footer ul > li + li:before { content: "|"; margin-right: 10px }
+
+*:last-child { margin-bottom: 0 }

--- a/docs.html
+++ b/docs.html
@@ -4,7 +4,7 @@ title: Documentation
 ---
 
 <h1>Documentation & Resources</h1>
-<p>Portal to documentation, guides and useful resources
-related to EPITA. <i class="fas fa-star"></i> = official resource.</p>
+<p>Portal to documentation, guides and useful resources related to EPITA.</p>
+<p class="small text-light"><i class="fas fa-star fa-fw"></i> = Official resource</p>
 
 {% include data-loader.html data = site.data.docs %}

--- a/docs.html
+++ b/docs.html
@@ -5,6 +5,6 @@ title: Documentation
 
 <h1>Documentation & Resources</h1>
 <p>Portal to documentation, guides and useful resources
-related to EPITA</p>
+related to EPITA. <i class="fas fa-star"></i> = official resource.</p>
 
 {% include data-loader.html data = site.data.docs %}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,6 @@ newsline: true
 ---
 
 <h1>EPITA.it</h1>
-<p>Portal to services and projects related to EPITA</p>
+<p>Portal to services and projects related to EPITA. <i class="fas fa-user-friends"></i> = community resource.</p>
 
 {% include grid-loader.html grid = site.data.links %}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@ newsline: true
 ---
 
 <h1>EPITA.it</h1>
-<p>Portal to services and projects related to EPITA. <i class="fas fa-user-friends"></i> = community resource.</p>
+<p>Portal to services and projects related to EPITA.</p>
+<p class="small text-light"><i class="fas fa-user-friends fa-fw"></i> = Community resource</p>
 
 {% include grid-loader.html grid = site.data.links %}


### PR DESCRIPTION
This PR adds community icons to the main page, and a "star" icon to the resources page. I think that distinguishing official and unofficial ("community") resources is important on pages where both are present in order to let people know "hey, this is not an official thing, it may contain mistakes, don't blame it on EPITA" and "hey, this is official, you can trust it".

* On the main page, because there is a minority of community websites, I added a "community" icon to community websites
* On the resources page, because there is only the CRI's documentation website which is official, I only added a star icon there

![image](https://user-images.githubusercontent.com/5175705/86295743-94717080-bbf7-11ea-9d06-078403017d98.png)
![image](https://user-images.githubusercontent.com/5175705/86295785-a8b56d80-bbf7-11ea-8f15-235280cfcb61.png)

One issue is that it overlaps with Dyjix's tile (can be fixed by positioning it, but it would require a slight tweak of how icons are laid out in Liquid on the data loading HTML) but... Why is Dyjix there in the first place? 🤔 

![image](https://user-images.githubusercontent.com/5175705/86295722-8ae80880-bbf7-11ea-9e73-5fc13a0bc3e3.png)
