### PR TITLE
Added awesome-epita

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -90,3 +90,8 @@
     style:
     - 'background-color: #fafafa'
 
+  - name: awesome-epita
+    href: https://github.com/ItsAnas/awesome-epita
+    class: tile-small-wide text-dark
+    style:
+    - 'background-color: #fafafa'


### PR DESCRIPTION
Adds [awesome-epita](https://github.com/ItsAnas/awesome-epita), which intends to be a collection of links to various lessons and courses for EPITA. I [quickly talked about the possibility of an overlap with EPITA.it](https://github.com/ItsAnas/awesome-epita/issues/1), but the repo seems to focus on being a list of links to repos, files, etc. while EPITA.it is more of a curated portal to services. I think it would be a good fit here.