### PR TITLE
Merging Debug-Pro tiles into one and removed sup-sub

### DIFF
--- a/_data/links.yml
+++ b/_data/links.yml
@@ -163,26 +163,19 @@
     - 'background-image: url(https://about.gitlab.com/images/press/logo/svg/gitlab-logo-white-rgb.svg)'
     - 'background-position-y: top'
     - 'background-size: 75%'
-
-  - name: Debug-Pro (Prog)
-    href: http://www.debug-pro.com/epita/prog/s0
-    class: tile-small-wide
-    style:
-    - 'background-color: #2f97b6'
-  
-- class: tile-medium
-  items:
-  - name: Debug-Pro (Archi)
-    relurl: debugpro
-    class: tile-small-wide text-dark
-    style:
-    - 'background-color: #f5f5ff'
     
   - name: Wiki Prog
     href: https://wiki-prog.infoprepa.epita.fr/index.php/EPITA:Programmation
     class: tile-small-wide text-dark
     style:
     - 'background-color: #f6f6f6'
+
+  
+- name: Debug-Pro
+  relurl: debugpro
+  class: tile-medium text-dark
+  style:
+  - 'background-color: #f5f5ff'
     
 - class: tile-medium
   items:

--- a/_data/links.yml
+++ b/_data/links.yml
@@ -283,14 +283,6 @@
   - 'background-image: url(https://pbs.twimg.com/profile_images/982210316581814272/okLNcPgm_200x200.jpg)'
   - 'background-position-x: right'
   
-- name: sup-sub
-  href: https://sup-sub.cri.epita.fr/
-  class: tile-small-wide
-  style:
-  - 'background-color: #014866'
-  - 'background-image: url(https://sup-sub.cri.epita.fr/static/project/img/logo-epita-nb.png)'
-  - 'background-position-x: right'
-  
 - name: LSE
   href: https://lse.epita.fr/
   class: tile-small-wide

--- a/_data/links.yml
+++ b/_data/links.yml
@@ -170,7 +170,6 @@
     style:
     - 'background-color: #f6f6f6'
 
-  
 - name: Debug-Pro
   relurl: debugpro
   class: tile-medium text-dark


### PR DESCRIPTION
Sup-sub tile is useless as it's no longer used for submissions and the URL returns a 502 Bad Gateway since a long time.

Debug-Pro tiles have been merged into one since one of the tiles already contained all the links