### PR TITLE
Add tonnerre.link card

### DIFF
--- a/_data/links.yml
+++ b/_data/links.yml
@@ -112,12 +112,12 @@
 
 - class: tile-medium
   items:
-  - name: Infinity Zeus
+  - name: tonnerre.link
     icon: fas fa-user-friends
-    href: https://zeus.infinity.study/
+    href: https://tonnerre.link/
     class: tile-small-wide
     style:
-    - 'background-color: #bd510a'
+    - 'background-color: #170e34'
 
   - name: Map EPITA
     icon: fas fa-user-friends


### PR DESCRIPTION
Since Infinity Zeus is no longer available, and since I made a website that covers some functionalities that Infinity Zeus used to have (.ics links), I replaced the Infinity Zeus card with one for tonnerre.link.