### PR TITLE
Remove kb.zoroark.guru from docs link

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -18,15 +18,6 @@
     - 'background-color: #1E1E1E'
     - 'background-size: 75%'
 
-  - name: kb.zoroark.guru
-    href: https://kb.zoroark.guru/
-    class: tile-medium
-    background_image: https://kb.zoroark.guru/favicon.png
-    style:
-    - 'background-color: #424242'
-    - 'background-position-y: 10%'
-    - 'background-size: 70%'
-
 - title: Guides
   items:
   - name: Guide de survie Projet S2 (FR)


### PR DESCRIPTION
Hello, my website [kb.zoroark.guru](https://kb.zoroark.guru) has been retired. As such, I don't think it's necessary to have it on epita.it (as it just sends people to a page that says "hey, this doesn't exist anymore"), so I removed the link.

Some of the (interesting) content has still been migrated to [my blog](https://blog.zoroark.guru/categories/kb-archive/), so I guess we could also put a link to my blog, but that feels more like self-promotion than something that's actually useful for epita.it to me.