### PR TITLE
Fix 2029 Discord tile name

### DIFF
--- a/app/src/data/2029.yml
+++ b/app/src/data/2029.yml
@@ -1,6 +1,6 @@
 - title: Student Community
   items:
-  - name: Discord EPITA 2028
+  - name: Discord EPITA 2029
     icon: icon-[fa-brands--discord]
     href: https://discord.gg/EuXuGTxyc8
     class: tile-wide


### PR DESCRIPTION
I made a mistake, I just changed 2028 to 2029