### PR TITLE
Add 2030 year group to navbar

### DIFF
--- a/app/app/src/data/navbar.yml
+++ b/app/app/src/data/navbar.yml
@@ -38,5 +38,8 @@
   - title: 2029
     href: /2029
 
+  - title: 2030
+    href: /2030
+
 - title: Archive
   href: /archive


### PR DESCRIPTION
Follow up to #173, because I keep forgetting how the code here works! (classic)
This PR adds what's usually required for users to discover the existence of a new page.